### PR TITLE
fix parseSimpleLayout

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,14 +44,14 @@ const parseSimpleLayout = (str, opts) => {
 
     if (fs.existsSync(hbsLayout)) { // eslint-disable-line no-sync
       const content = fs.readFileSync(hbsLayout, { encoding: 'utf-8' }); // eslint-disable-line no-sync
-      return content.replace('{{{body}}}', { dependencies: [hbsLayout], content: str });
+      return { dependencies: [hbsLayout], content: content.replace('{{{body}}}', str) };
     }
 
     const handlebarsLayout = hbsLayout.replace('.hbs', '.handlebars');
 
     if (fs.existsSync(handlebarsLayout)) { // eslint-disable-line no-sync
       const content = fs.readFileSync(handlebarsLayout, { encoding: 'utf-8' }); // eslint-disable-line no-sync
-      return content.replace('{{{body}}}', { dependencies: [handlebarsLayout], content: str });
+      return { dependencies: [handlebarsLayout], content: content.replace('{{{body}}}', str) };
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-    "name": "parcel-plugin-handlebars-nf",
-    "version": "0.4.9",
+    "name": "@native_finance/parcel-plugin-handlebars",
+    "version": "0.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
function should always return an object like `{ dependencies, content }`